### PR TITLE
Removed subdomains from legitimate domain requests

### DIFF
--- a/bro_typosquatting.bro
+++ b/bro_typosquatting.bro
@@ -9,13 +9,22 @@ export {
     redef legit_domains = {"google.com","microsoft.com"};
 }
 
+function typo_split(str: string): string {
+local vec = split_all(str,/\./);
+local out = vec[|vec|-2] + vec[|vec|-1] + vec[|vec|];
+
+return out;
+}
+
 event dns_request(c: connection, msg: dns_msg, query: string, qtype: count, qclass: count) {
 	local dist: double;
 	for ( i in legit_domains ) {
-		dist = levenshtein_distance(query,i);
+		local clean_query = typo_split(query);
+		dist = levenshtein_distance(clean_query,i);
 		if ( 0 < dist && dist < 5) {
 			NOTICE([$note=Typosquat,
-				$msg = fmt("Request to typosquatted domain name %s",query),
+				$msg = fmt("Request to typosquatted domain name %s",clean_query),
+				$sub = fmt("Legitimate domain: %s",i),
 				$conn=c]);
 				
 		}


### PR DESCRIPTION
This addition is a bandaid fix for an issue where subdomains of legitimate domains will trigger the alert. This fix doesn't address country-code TLDs, but those should not be a problem unless the user inserts them into the legit_domains variable.

This also adds the legitimate domain to the notice in the $sub field.
